### PR TITLE
Remove deprecated option ReportReserved

### DIFF
--- a/debian/collectd/readsb.collectd.conf
+++ b/debian/collectd/readsb.collectd.conf
@@ -84,7 +84,6 @@ LoadPlugin exec
 <Plugin "df">
 	MountPoint "/"
 	IgnoreSelected false
-	ReportReserved true
 	ReportInodes true
 </Plugin>
 


### PR DESCRIPTION
This option was removed in version 5.4.3: https://github.com/collectd/collectd/blob/e0f1eb65c29b05761017cffccd87183f45c0a010/ChangeLog#L1669
With stricter checking of deprecated options this leads to an startup error on Ubuntu 20.04 (and collectd 5.9.0): https://github.com/collectd/collectd/issues/3208